### PR TITLE
Change the aravis dependency name

### DIFF
--- a/camera_aravis.orogen
+++ b/camera_aravis.orogen
@@ -1,7 +1,7 @@
 name "camera_aravis"
 # version "0.1"
 
-using_library "aravis-0.4"
+using_library "aravis-0.6"
 using_library "camera_aravis"
 using_task_library "camera_base"
 


### PR DESCRIPTION
The aravis library name has changed from the version 0.4 to 0.6]

This depends on these PRs:
- [x] https://github.com/rock-drivers/drivers-camera_aravis/pull/2
- [x] https://github.com/AravisProject/aravis/pull/10
