### PR TITLE
Add the possibility of restart the camera timestamp counter

### DIFF
--- a/camera_aravis.orogen
+++ b/camera_aravis.orogen
@@ -12,6 +12,10 @@ task_context 'Task' do
     # This might helpful if the device is in an unknown or not working state.
     # Note that the startup of the driver will be significantly slower.
     property('reset_device_on_startup', 'bool', false)
+    # Reset the timestamp register in the camera and save the time it was
+    # performed.  This time is added to the frame's timestamp. Useful when
+    # camera restart its counter at reseting or powering on.
+    property('reset_timestamp', 'bool', false)
 
     # Specifies the max packet size on an ethernet connection. Default is 1500.
     property('eth_packet_size', 'int', 1500)

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -32,6 +32,9 @@ bool Task::configureHook()
     CameraAravis* camera = new CameraAravis();
     camera->openCamera(_camera_id.value(), _eth_packet_size.value());
 
+    if(_reset_timestamp.value())
+        camera->resetTimestamp();
+
     cam_interface = camera;
     cam_interface->setCallbackFcn(triggerFunction,this);
     return true;


### PR DESCRIPTION
This will also save the time when the action occurred, so the camera driver
will add that time to the frame timestamp returned by the camera.

Depends on: https://github.com/rock-drivers/drivers-camera_aravis/pull/7